### PR TITLE
Feature: Added es5 and node package exports

### DIFF
--- a/.changes/unreleased/Fixed-20240620-094941.yaml
+++ b/.changes/unreleased/Fixed-20240620-094941.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Support for importing from node platform using `import` syntax
+time: 2024-06-20T09:49:41.580826796+10:00

--- a/package.json
+++ b/package.json
@@ -62,26 +62,31 @@
     "typedoc-plugin-rename-defaults": "^0.7.0",
     "typescript": "^5.4.5"
   },
-  "main": "./dist/es/index.js",
-  "types": "./dist/es/index.d.ts",
+  "types": "./dist/esm/index.d.ts",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm5/index.js",
+  "es2015": "./dist/esm/index.js",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
+      "node": "./dist/cjs/index.js",
       "require": "./dist/cjs/index.js",
-      "import": "./dist/es/index.js",
-      "default": "./dist/es/index.js"
+      "import": "./dist/esm/index.js",
+      "default": "./dist/es5/index.js"
     },
     "./internal/*": {
       "types": "./dist/types/internal/*.d.ts",
+      "node": "./dist/cjs/internal/*.js",
       "require": "./dist/cjs/internal/*.js",
-      "import": "./dist/es/internal/*.js",
-      "default": "./dist/es/internal/*.js"
+      "import": "./dist/esm/internal/*.js",
+      "default": "./dist/es5/internal/*.js"
     },
     "./*": {
       "types": "./dist/types/*.d.ts",
+      "node": "./dist/cjs/*.js",
       "require": "./dist/cjs/*.js",
-      "import": "./dist/es/*.js",
-      "default": "./dist/es/*.js"
+      "import": "./dist/esm/*.js",
+      "default": "./dist/es5/*.js"
     },
     "./package.json": "./package.json"
   },

--- a/package.json
+++ b/package.json
@@ -4,10 +4,7 @@
   "description": "Javascript Iterable/Iterator/Generator-function utilities.",
   "sideEffects": false,
   "scripts": {
-    "build": "concurrently \"pnpm run build:cjs\" \"pnpm run build:es\" \"pnpm run build:types\"",
-    "build:cjs": "tsc -p tsconfig.json",
-    "build:es": "tsc -p tsconfig.es.json",
-    "build:types": "tsc -p tsconfig.types.json",
+    "build": "concurrently \"tsc -p tsconfig.json\" \"tsc -p tsconfig.es5.json\" \"tsc -p tsconfig.esm.json\" \"tsc -p tsconfig.types.json\"",
     "clean": "rimraf dist iteragain*.tgz",
     "asyncify": "ts-node ./scripts/asyncify.ts",
     "asyncify:watch": "ts-node ./scripts/asyncify.ts -w",

--- a/tsconfig.es5.json
+++ b/tsconfig.es5.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "target": "es5",
+    "module": "es2015",
+    "outDir": "./dist/es5"
+  }
+}

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,8 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "target": "es6",
+    "target": "es2015",
     "module": "es2015",
-    "outDir": "./dist/es"
+    "outDir": "./dist/esm"
   }
 }

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./tsconfig.es.json",
+  "extends": "./tsconfig.esm.json",
   "compilerOptions": {
     "outDir": "./dist/types/",
     "declaration": true,


### PR DESCRIPTION
Description of changes:
- Added es5 build,
- Removed es build in favour of esm which has a es2015 target instead of es6.
- Added node package export to point to cjs.
- `import` package exports prop now points to the esm build. 

Checklist:
- [-] ~Added/edited tests (if applicable)~
- [x] Added changelog entry (if applicable), i.e. `pnpm changie new`
- [-] ~Updated README (if applicable)~
